### PR TITLE
Update OctoPack.targets Add Version append for manual 

### DIFF
--- a/source/tools/OctoPack.targets
+++ b/source/tools/OctoPack.targets
@@ -20,9 +20,10 @@
     <OctoPackIncludeTypeScriptSourceFiles Condition="'$(OctoPackIncludeTypeScriptSourceFiles)'==''">false</OctoPackIncludeTypeScriptSourceFiles>
     <OctoPackNuSpecFileName Condition="'$(OctoPackNuSpecFileName)' == ''"></OctoPackNuSpecFileName>
     <OctoPackAppendToPackageId Condition="'$(OctoPackAppendToPackageId)' == ''"></OctoPackAppendToPackageId>
-    <OctoPackAppendToVersion Condition="$(OctoPackAppendToVersion)==''"></OctoPackAppendToVersion>
-    <OctoPackAppendToVersion Condition="$(OctoPackAppendToVersion)!=''">$(OctoPackAppendToVersion)</OctoPackAppendToVersion>
-    <OctoPackAppendToVersion Condition="$(OctoPackAppendToVersion)!='' and not $(OctoPackAppendToVersion).StartsWith('-')">-$(OctoPackAppendToVersion)</OctoPackAppendToVersion>
+        
+    <OctoPackAppendToVersion Condition="'$(OctoPackAppendToVersion)' == ''"></OctoPackAppendToVersion>    
+    <OctoPackAppendToVersion Condition="'$(OctoPackAppendToVersion)' != '' AND !($(OctoPackAppendToVersion->StartsWith('-')))">-$(OctoPackAppendToVersion)</OctoPackAppendToVersion>
+    
     <OctoPackReleaseNotesFile Condition="'$(OctoPackReleaseNotesFile)' == ''"></OctoPackReleaseNotesFile>
     <OctoPackNuGetExePath Condition="'$(OctoPackNuGetExePath)' == ''"></OctoPackNuGetExePath>
     <OctoPackPublishPackageToFileShare Condition="'$(OctoPackPublishPackageToFileShare)' == ''"></OctoPackPublishPackageToFileShare>

--- a/source/tools/OctoPack.targets
+++ b/source/tools/OctoPack.targets
@@ -20,6 +20,8 @@
     <OctoPackIncludeTypeScriptSourceFiles Condition="'$(OctoPackIncludeTypeScriptSourceFiles)'==''">false</OctoPackIncludeTypeScriptSourceFiles>
     <OctoPackNuSpecFileName Condition="'$(OctoPackNuSpecFileName)' == ''"></OctoPackNuSpecFileName>
     <OctoPackAppendToPackageId Condition="'$(OctoPackAppendToPackageId)' == ''"></OctoPackAppendToPackageId>
+    <OctoPackAppendToVersion Condition="$(OctoPackAppendToVersion)!=''">$(OctoPackAppendToVersion)</OctoPackAppendToVersion>
+    <OctoPackAppendToVersion Condition="$(OctoPackAppendToVersion)!='' and not $(OctoPackAppendToVersion).StartsWith('-')">-$(OctoPackAppendToVersion)</OctoPackAppendToVersion>
     <OctoPackReleaseNotesFile Condition="'$(OctoPackReleaseNotesFile)' == ''"></OctoPackReleaseNotesFile>
     <OctoPackNuGetExePath Condition="'$(OctoPackNuGetExePath)' == ''"></OctoPackNuGetExePath>
     <OctoPackPublishPackageToFileShare Condition="'$(OctoPackPublishPackageToFileShare)' == ''"></OctoPackPublishPackageToFileShare>
@@ -78,7 +80,7 @@
       OutDir="$(OutDir)"
       ProjectDirectory="$(MSBuildProjectDirectory)"
       ProjectName="$(OctoPackProjectName)"
-      PackageVersion="$(OctoPackPackageVersion)"
+      PackageVersion="$(OctoPackPackageVersion)$(OctoPackAppendToVersion)"
       PrimaryOutputAssembly="$(TargetPath)"
       ReleaseNotesFile="$(OctoPackReleaseNotesFile)"
       NuGetExePath="$(OctoPackNuGetExePath)"

--- a/source/tools/OctoPack.targets
+++ b/source/tools/OctoPack.targets
@@ -20,10 +20,7 @@
     <OctoPackIncludeTypeScriptSourceFiles Condition="'$(OctoPackIncludeTypeScriptSourceFiles)'==''">false</OctoPackIncludeTypeScriptSourceFiles>
     <OctoPackNuSpecFileName Condition="'$(OctoPackNuSpecFileName)' == ''"></OctoPackNuSpecFileName>
     <OctoPackAppendToPackageId Condition="'$(OctoPackAppendToPackageId)' == ''"></OctoPackAppendToPackageId>
-        
-    <OctoPackAppendToVersion Condition="'$(OctoPackAppendToVersion)' == ''"></OctoPackAppendToVersion>    
-    <OctoPackAppendToVersion Condition="'$(OctoPackAppendToVersion)' != '' AND !($(OctoPackAppendToVersion->StartsWith('-')))">-$(OctoPackAppendToVersion)</OctoPackAppendToVersion>
-    
+    <OctoPackAppendToVersion Condition="'$(OctoPackAppendToVersion)' == ''"></OctoPackAppendToVersion>
     <OctoPackReleaseNotesFile Condition="'$(OctoPackReleaseNotesFile)' == ''"></OctoPackReleaseNotesFile>
     <OctoPackNuGetExePath Condition="'$(OctoPackNuGetExePath)' == ''"></OctoPackNuGetExePath>
     <OctoPackPublishPackageToFileShare Condition="'$(OctoPackPublishPackageToFileShare)' == ''"></OctoPackPublishPackageToFileShare>
@@ -57,9 +54,11 @@
     <PropertyGroup>
       <OctoPackNuGetProperties Condition="'$(OctoPackNuGetProperties)' == ''"></OctoPackNuGetProperties>
     </PropertyGroup>
-	<!--
-		Append project name so that you can nest packages in a structure such as [orgName]/[PackageName]/PackageName.Version.nupkg
-	-->
+    <PropertyGroup>
+      <!-- Make sure the append version has a leading dash for nuget-->
+      <OctoPackAppendToVersion Condition="$(OctoPackAppendToVersion.StartsWith('-')) == False">-$(OctoPackAppendToVersion)</OctoPackAppendToVersion>            
+    </PropertyGroup>
+    <!-- Append project name so that you can nest packages in a structure such as [orgName]/[PackageName]/PackageName.Version.nupkg -->
     <PropertyGroup>
       <OctoPackPublishPackageToHttp Condition="'$(OctoPackPublishPackageToHttp)' != '' AND '$(OctoPackAppendProjectToFeed)'">$(OctoPackPublishPackageToHttp)/$(MSBuildProjectName)</OctoPackPublishPackageToHttp>
     </PropertyGroup>

--- a/source/tools/OctoPack.targets
+++ b/source/tools/OctoPack.targets
@@ -56,7 +56,7 @@
     </PropertyGroup>
     <PropertyGroup>
       <!-- Make sure the append version has a leading dash for nuget-->
-      <OctoPackAppendToVersion Condition="$(OctoPackAppendToVersion.StartsWith('-')) == False">-$(OctoPackAppendToVersion)</OctoPackAppendToVersion>            
+      <OctoPackAppendToVersion Condition="'$(OctoPackAppendToVersion)' != '' AND $(OctoPackAppendToVersion.StartsWith('-')) == False">-$(OctoPackAppendToVersion)</OctoPackAppendToVersion>            
     </PropertyGroup>
     <!-- Append project name so that you can nest packages in a structure such as [orgName]/[PackageName]/PackageName.Version.nupkg -->
     <PropertyGroup>

--- a/source/tools/OctoPack.targets
+++ b/source/tools/OctoPack.targets
@@ -20,6 +20,7 @@
     <OctoPackIncludeTypeScriptSourceFiles Condition="'$(OctoPackIncludeTypeScriptSourceFiles)'==''">false</OctoPackIncludeTypeScriptSourceFiles>
     <OctoPackNuSpecFileName Condition="'$(OctoPackNuSpecFileName)' == ''"></OctoPackNuSpecFileName>
     <OctoPackAppendToPackageId Condition="'$(OctoPackAppendToPackageId)' == ''"></OctoPackAppendToPackageId>
+    <OctoPackAppendToVersion Condition="$(OctoPackAppendToVersion)==''"></OctoPackAppendToVersion>
     <OctoPackAppendToVersion Condition="$(OctoPackAppendToVersion)!=''">$(OctoPackAppendToVersion)</OctoPackAppendToVersion>
     <OctoPackAppendToVersion Condition="$(OctoPackAppendToVersion)!='' and not $(OctoPackAppendToVersion).StartsWith('-')">-$(OctoPackAppendToVersion)</OctoPackAppendToVersion>
     <OctoPackReleaseNotesFile Condition="'$(OctoPackReleaseNotesFile)' == ''"></OctoPackReleaseNotesFile>


### PR DESCRIPTION
Modified targets to allow passing of an appended version field.  Intended usage being to create a semver version number that will allow differentiation of trunk and branch builds.
